### PR TITLE
URL connection spoofs Firefox user agent string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,18 @@
     <groupId>com.icosillion</groupId>
     <artifactId>PodcastLibrary</artifactId>
     <version>2.0.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/icosillion/podengine/models/Podcast.java
+++ b/src/main/java/com/icosillion/podengine/models/Podcast.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.*;
 
 public class Podcast {
@@ -38,9 +39,14 @@ public class Podcast {
     private List<Episode> episodes;
 
     public Podcast(URL feed) throws InvalidFeedException, MalformedFeedException {
+        URLConnection ic = null;
         InputStream is = null;
+
         try {
-            is = feed.openStream();
+            ic = feed.openConnection();
+            ic.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1");
+            is = ic.getInputStream();
+
             this.feedURL = feed;
             this.xmlData = IOUtils.toString(is);
             this.document = DocumentHelper.parseText(xmlData);
@@ -50,6 +56,7 @@ public class Podcast {
                 throw new MalformedFeedException("Missing required channel element.");
             }
         } catch (IOException e) {
+            e.printStackTrace();
             throw new InvalidFeedException("Error reading feed.", e);
         } catch (DocumentException e) {
             throw new InvalidFeedException("Error parsing feed XML.", e);

--- a/src/test/java/com/icosillion/podengine/models/PodcastTest.java
+++ b/src/test/java/com/icosillion/podengine/models/PodcastTest.java
@@ -17,8 +17,9 @@ public class PodcastTest {
     @Test
     public void testPodcastFeedCreation(){
         try {
-            Podcast podcast = new Podcast(new URL("http://feeds.feedburner.com/thetimferrissshow"));
-            assertEquals("The Tim Ferriss Show", podcast.getTitle());
+            Podcast podcast = new Podcast(new URL("https://www.relay.fm/cortex/feed"));
+            System.out.println(podcast.getTitle());
+            System.out.println(podcast.getDescription());
         } catch (InvalidFeedException e) {
             e.printStackTrace();
         } catch (MalformedURLException e) {

--- a/src/test/java/com/icosillion/podengine/models/PodcastTest.java
+++ b/src/test/java/com/icosillion/podengine/models/PodcastTest.java
@@ -17,9 +17,8 @@ public class PodcastTest {
     @Test
     public void testPodcastFeedCreation(){
         try {
-            Podcast podcast = new Podcast(new URL("https://www.relay.fm/cortex/feed"));
-            System.out.println(podcast.getTitle());
-            System.out.println(podcast.getDescription());
+            Podcast podcast = new Podcast(new URL("http://feeds.feedburner.com/thetimferrissshow"));
+            assertEquals("The Tim Ferriss Show", podcast.getTitle());
         } catch (InvalidFeedException e) {
             e.printStackTrace();
         } catch (MalformedURLException e) {


### PR DESCRIPTION
Hey I was just checking out this library and kept encountering a 403 error from relay.fm's podcasts like cortex and so I created a url connection and spoofed Firefox's user agent string to bypass their restrictions. Thank you for this.