### PR TITLE
Fixed getEpisodes method

### DIFF
--- a/src/main/java/com/icosillion/podengine/models/Podcast.java
+++ b/src/main/java/com/icosillion/podengine/models/Podcast.java
@@ -544,7 +544,7 @@ public class Podcast {
         }
 
         List<Episode> episodes = new ArrayList<>();
-        for (Object itemObject : this.rootElement.elements("item")) {
+        for (Object itemObject : this.channelElement.elements("item")) {
             if (!(itemObject instanceof Element)) {
                 continue;
             }


### PR DESCRIPTION
Hey, I was messing around with this library and noticed an error in the getEpisodes method. Episode items should be sub elements of the channel element, not the root element. I changed it so that it looks for items in the channel element instead. Thanks for making this by the way.