### PR TITLE
Use US Locale for date parser

### DIFF
--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -5,14 +5,15 @@ import com.icosillion.podengine.exceptions.DateFormatException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public class DateUtils {
 
     private static SimpleDateFormat[] dateFormats = {
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z"),
-            new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z"),
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm Z"),
-            new SimpleDateFormat("dd MMM yyyy HH:mm Z")
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US),
+            new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.US),
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm Z", Locale.US),
+            new SimpleDateFormat("dd MMM yyyy HH:mm Z", Locale.US)
     };
 
     public static Date stringToDate(String dt) throws DateFormatException {


### PR DESCRIPTION
The vast majority of RSS feeds use US locale for the pubDate.  This library fails to parse the pubDate when Android is set to a non US locale.