### PR TITLE
Fix parsing pubDate

### DIFF
--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -9,18 +9,17 @@ import java.util.Locale;
 
 public class DateUtils {
 
-    private static SimpleDateFormat[] dateFormats = {
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US),
-            new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.US),
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm Z", Locale.US),
-            new SimpleDateFormat("dd MMM yyyy HH:mm Z", Locale.US)
-    };
-
     public static Date stringToDate(String dt) throws DateFormatException {
+        SimpleDateFormat[] dateFormats = {
+                new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US),
+                new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.US),
+                new SimpleDateFormat("EEE, dd MMM yyyy HH:mm Z", Locale.US),
+                new SimpleDateFormat("dd MMM yyyy HH:mm Z", Locale.US)
+        };
 
         Date date = null;
 
-        for (SimpleDateFormat dateFormat : DateUtils.dateFormats) {
+        for (SimpleDateFormat dateFormat : dateFormats) {
             try {
                 date = dateFormat.parse(dt);
                 break;

--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -8,16 +8,6 @@ import java.util.Locale;
 public class DateUtils {
 
     public static Date stringToDate(String dt) {
-        Date result = parseWithStandardDateFormats(dt);
-
-        if (result == null) {
-            return parseWithStandardDateFormats(normalize(dt));
-        } else {
-            return result;
-        }
-    }
-
-    private static Date parseWithStandardDateFormats(String dt) {
         SimpleDateFormat[] dateFormats = {
                 new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US),
                 new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.US),
@@ -25,11 +15,13 @@ public class DateUtils {
                 new SimpleDateFormat("dd MMM yyyy HH:mm Z", Locale.US)
         };
 
+        String normalizedDt = normalize(dt);
+
         Date date = null;
 
         for (SimpleDateFormat dateFormat : dateFormats) {
             try {
-                date = dateFormat.parse(dt);
+                date = dateFormat.parse(normalizedDt);
                 break;
             } catch (ParseException e) {
                 //This format didn't work, keep going

--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -1,7 +1,5 @@
 package com.icosillion.podengine.utils;
 
-import com.icosillion.podengine.exceptions.DateFormatException;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -9,7 +7,17 @@ import java.util.Locale;
 
 public class DateUtils {
 
-    public static Date stringToDate(String dt) throws DateFormatException {
+    public static Date stringToDate(String dt) {
+        Date result = parseWithStandardDateFormats(dt);
+
+        if (result == null) {
+            return parseWithStandardDateFormats(normalize(dt));
+        } else {
+            return result;
+        }
+    }
+
+    private static Date parseWithStandardDateFormats(String dt) {
         SimpleDateFormat[] dateFormats = {
                 new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US),
                 new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.US),
@@ -29,5 +37,11 @@ public class DateUtils {
         }
 
         return date;
+    }
+
+    private static String normalize(String dt) {
+        return dt.replace("Tues,", "Tue,")
+                 .replace("Thurs,", "Thu,")
+                 .replace("Wednes,", "Wed,");
     }
 }

--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -11,10 +11,14 @@ public class DateUtils {
         Date result = parseWithStandardDateFormats(dt);
 
         if (result == null) {
-            return parseWithStandardDateFormats(normalize(dt));
-        } else {
-            return result;
+            result = parseWithStandardDateFormats(normalize(dt));
+
+            if (result == null) {
+                System.out.println("!!! Unable to parse date: " + dt);
+            }
         }
+
+        return result;
     }
 
     private static Date parseWithStandardDateFormats(String dt) {

--- a/src/main/java/com/icosillion/podengine/utils/DateUtils.java
+++ b/src/main/java/com/icosillion/podengine/utils/DateUtils.java
@@ -11,14 +11,10 @@ public class DateUtils {
         Date result = parseWithStandardDateFormats(dt);
 
         if (result == null) {
-            result = parseWithStandardDateFormats(normalize(dt));
-
-            if (result == null) {
-                System.out.println("!!! Unable to parse date: " + dt);
-            }
+            return parseWithStandardDateFormats(normalize(dt));
+        } else {
+            return result;
         }
-
-        return result;
     }
 
     private static Date parseWithStandardDateFormats(String dt) {

--- a/src/test/java/com/icosillion/podengine/utils/DateUtilsTest.java
+++ b/src/test/java/com/icosillion/podengine/utils/DateUtilsTest.java
@@ -1,0 +1,38 @@
+package com.icosillion.podengine.utils;
+
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DateUtilsTest {
+
+    private static final SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+
+    @Test
+    public void parsesStandardDateFormats() {
+        String dateTime = "Tue, 03 March 2009 15:00:00 -0000";
+
+        Date date = DateUtils.stringToDate(dateTime);
+
+        assertNotNull(date);
+        assertEquals("Tue, 03 Mar 2009 16:00:00 +0100", sdf.format(date));
+    }
+
+    @Test
+    public void parsesNonStandardDateFormats() {
+        assertEquals("Tue, 03 Mar 2009 16:00:00 +0100",
+                     sdf.format(DateUtils.stringToDate("Tues, 03 March 2009 15:00:00 -0000")));
+
+        assertEquals("Wed, 04 Mar 2009 16:00:00 +0100",
+                     sdf.format(DateUtils.stringToDate("Wednes, 04 March 2009 15:00:00 -0000")));
+
+        assertEquals("Thu, 05 Mar 2009 16:00:00 +0100",
+                     sdf.format(DateUtils.stringToDate("Thurs, 05 March 2009 15:00:00 -0000")));
+    }
+
+}


### PR DESCRIPTION
Fixes two issues with parsing episode publication date:

- `SimpleDataFormat` is not thread safe, it can give incorrect results in multithread environment
- some episodes have non standard day of the week format, for example instead of `Tue` for Tuesday they have `Tues` etc.